### PR TITLE
Expose OpenAI key via BuildConfig

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,12 @@ plugins {
     id("org.jetbrains.kotlin.kapt")
 }
 
+import java.util.Properties
+
+val properties = Properties().apply {
+    load(rootProject.file("local.properties").inputStream())
+}
+
 android {
     namespace = "com.example.myapplication111"
     compileSdk = 35
@@ -17,6 +23,8 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        buildConfigField("String", "OPENAI_KEY", "\"${properties["openaiKey"]}\"")
     }
 
     buildTypes {

--- a/app/src/main/java/com/example/myapplication111/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication111/MainActivity.kt
@@ -29,7 +29,7 @@ data class Message(val sender: String, val content: String)
 
 class MainActivity : ComponentActivity() {
 
-    private val apiKey = ""
+    private val apiKey = BuildConfig.OPENAI_KEY
     private lateinit var db: AppDatabase
     private val messages = mutableStateListOf<Message>()
 


### PR DESCRIPTION
## Summary
- Load `openaiKey` from `local.properties` and expose it as `OPENAI_KEY` in BuildConfig
- Read the key via `BuildConfig.OPENAI_KEY` in `MainActivity`

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893be4f06688333919cd93addf511ca