### PR TITLE
feat: modern owl-themed chat design

### DIFF
--- a/app/src/main/java/com/example/myapplication111/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication111/MainActivity.kt
@@ -3,21 +3,26 @@ package com.example.myapplication111
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.shape.RoundedCornerShape
 import com.android.volley.toolbox.StringRequest
 import com.android.volley.toolbox.Volley
 import com.android.volley.Request
 import com.android.volley.NetworkResponse
 import com.android.volley.Response
 import com.android.volley.toolbox.HttpHeaderParser
-import androidx.compose.ui.Alignment
 import org.json.JSONObject
 import com.example.myapplication111.ui.theme.MyApplication111Theme
 import androidx.lifecycle.lifecycleScope
@@ -50,62 +55,97 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private fun newChat() {
+        messages.clear()
+    }
+
+    private fun clearHistory() {
+        lifecycleScope.launch {
+            db.messageDao().clearAll()
+        }
+        messages.clear()
+    }
+
     @Composable
     fun ChatScreen() {
         var userMessage by remember { mutableStateOf("") }
         val messages = this@MainActivity.messages
         val context = this
 
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-        ) {
-            LazyColumn(modifier = Modifier.weight(1f)) {
-                items(messages) { message ->
-                    if (message.sender == "user") {
-                        UserMessageBubble(message.content)
-                    } else {
-                        BotMessageBubble(message.content)
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = { Text("EPN Chat") },
+                    navigationIcon = {
+                        Image(
+                            painter = painterResource(R.drawable.ic_owl),
+                            contentDescription = "Owl icon",
+                            modifier = Modifier.padding(horizontal = 8.dp)
+                        )
+                    },
+                    actions = {
+                        IconButton(onClick = { newChat() }) {
+                            Icon(Icons.Default.Add, contentDescription = "New Chat")
+                        }
+                        IconButton(onClick = { clearHistory() }) {
+                            Icon(Icons.Default.Delete, contentDescription = "Clear History")
+                        }
+                    }
+                )
+            }
+        ) { padding ->
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .padding(16.dp)
+            ) {
+                LazyColumn(modifier = Modifier.weight(1f)) {
+                    items(messages) { message ->
+                        if (message.sender == "user") {
+                            UserMessageBubble(message.content)
+                        } else {
+                            BotMessageBubble(message.content)
+                        }
                     }
                 }
-            }
 
-            Row(modifier = Modifier.fillMaxWidth()) {
-                TextField(
-                    value = userMessage,
-                    onValueChange = { userMessage = it },
-                    placeholder = { Text("Escribe tu mensaje") },
-                    modifier = Modifier.weight(1f)
-                )
+                Row(modifier = Modifier.fillMaxWidth()) {
+                    TextField(
+                        value = userMessage,
+                        onValueChange = { userMessage = it },
+                        placeholder = { Text("Escribe tu mensaje") },
+                        modifier = Modifier.weight(1f)
+                    )
 
-                Spacer(modifier = Modifier.width(8.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
 
-                Button(
-                    onClick = {
-                        if (userMessage.isNotBlank()) {
-                            val content = userMessage
-                            this@MainActivity.lifecycleScope.launch {
-                                db.messageDao().insert(
-                                    MessageEntity(sender = "user", content = content, timestamp = System.currentTimeMillis())
-                                )
-                            }
-                            messages.add(Message("user", content))
-                            callChatGPTAPI(context, content) { response ->
-                                val botReply = response ?: "No se recibió respuesta"
+                    Button(
+                        onClick = {
+                            if (userMessage.isNotBlank()) {
+                                val content = userMessage
                                 this@MainActivity.lifecycleScope.launch {
                                     db.messageDao().insert(
-                                        MessageEntity(sender = "bot", content = botReply, timestamp = System.currentTimeMillis())
+                                        MessageEntity(sender = "user", content = content, timestamp = System.currentTimeMillis())
                                     )
                                 }
-                                messages.add(Message("bot", botReply))
+                                messages.add(Message("user", content))
+                                callChatGPTAPI(context, content) { response ->
+                                    val botReply = response ?: "No se recibió respuesta"
+                                    this@MainActivity.lifecycleScope.launch {
+                                        db.messageDao().insert(
+                                            MessageEntity(sender = "bot", content = botReply, timestamp = System.currentTimeMillis())
+                                        )
+                                    }
+                                    messages.add(Message("bot", botReply))
+                                }
+                                userMessage = ""
                             }
-                            userMessage = ""
-                        }
-                    },
-                    modifier = Modifier.align(Alignment.CenterVertically)
-                ) {
-                    Text("Enviar")
+                        },
+                        modifier = Modifier.align(Alignment.CenterVertically)
+                    ) {
+                        Text("Enviar")
+                    }
                 }
             }
         }
@@ -113,25 +153,31 @@ class MainActivity : ComponentActivity() {
 
     @Composable
     fun UserMessageBubble(text: String) {
-        Surface(
-            color = Color(0xFFE0E0E0),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.End
         ) {
-            Text(text = text, modifier = Modifier.padding(8.dp))
+            Surface(
+                color = MaterialTheme.colorScheme.primary,
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(text = text, color = MaterialTheme.colorScheme.onPrimary, modifier = Modifier.padding(12.dp))
+            }
         }
     }
 
     @Composable
     fun BotMessageBubble(text: String) {
-        Surface(
-            color = Color(0xFFF5F5F5),
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.Start
         ) {
-            Text(text = text, modifier = Modifier.padding(8.dp))
+            Surface(
+                color = MaterialTheme.colorScheme.secondary,
+                shape = RoundedCornerShape(16.dp)
+            ) {
+                Text(text = text, color = MaterialTheme.colorScheme.onSecondary, modifier = Modifier.padding(12.dp))
+            }
         }
     }
 

--- a/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
+++ b/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
@@ -11,4 +11,7 @@ interface MessageDao {
 
     @Query("SELECT * FROM messages ORDER BY timestamp ASC")
     suspend fun getAll(): List<MessageEntity>
+
+    @Query("DELETE FROM messages")
+    suspend fun clearAll()
 }

--- a/app/src/main/java/com/example/myapplication111/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/myapplication111/ui/theme/Color.kt
@@ -2,7 +2,8 @@ package com.example.myapplication111.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+val EpnBlue = Color(0xFF003C8F)
+val EpnRed = Color(0xFFD50000)
+val OwlGray = Color(0xFFF5F5F5)
 val White = Color(0xFFFFFFFF)
-val LightGray = Color(0xFFE0E0E0)
 val DarkGray = Color(0xFF212121)
-

--- a/app/src/main/java/com/example/myapplication111/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/myapplication111/ui/theme/Theme.kt
@@ -7,8 +7,8 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 
 private val DarkColorScheme = darkColorScheme(
-    primary = DarkGray,
-    secondary = LightGray,
+    primary = EpnBlue,
+    secondary = EpnRed,
     background = DarkGray,
     surface = DarkGray,
     onPrimary = White,
@@ -18,12 +18,12 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = White,
-    secondary = LightGray,
+    primary = EpnBlue,
+    secondary = EpnRed,
     background = White,
-    surface = LightGray,
-    onPrimary = DarkGray,
-    onSecondary = DarkGray,
+    surface = OwlGray,
+    onPrimary = White,
+    onSecondary = White,
     onBackground = DarkGray,
     onSurface = DarkGray
 )
@@ -41,4 +41,3 @@ fun MyApplication111Theme(
         content = content
     )
 }
-

--- a/app/src/main/res/drawable/ic_owl.xml
+++ b/app/src/main/res/drawable/ic_owl.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,2C8,2 5,5 5,8c0,3 2,5 4,6v4l3-2 3,2v-4c2-1 4-3 4-6 0-3-3-6-7-6z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z"/>
+</vector>


### PR DESCRIPTION
## Summary
- Refresh chat UI with owl-themed top bar and modern message bubbles
- Enable starting new conversations and clearing chat history
- Introduce EPN color scheme and reusable owl icon asset

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893c7e50a0c8333bf08f0a442197973