### PR TITLE
Fix KAPT configuration for Room

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -73,4 +73,3 @@ dependencies {
     debugImplementation(libs.androidx.ui.test.manifest)
 }
 
-private fun DependencyHandlerScope.kapt(string: String) {}


### PR DESCRIPTION
## Summary
- remove custom kapt extension stub
- ensure Room compiler is processed by kapt plugin

## Testing
- `gradle clean build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893cc9a2c4c8333a3ec72d5b08d1bfe