### PR TITLE
feat: apply neutral dark theme

### DIFF
--- a/app/src/main/java/com/example/myapplication111/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/myapplication111/ui/theme/Color.kt
@@ -2,8 +2,11 @@ package com.example.myapplication111.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val EpnBlue = Color(0xFF003C8F)
-val EpnRed = Color(0xFFD50000)
-val OwlGray = Color(0xFFF5F5F5)
-val White = Color(0xFFFFFFFF)
+// Neutral color palette without institutional references
+val DeepBlue = Color(0xFF0D47A1)
+val SlateGray = Color(0xFF607D8B)
+val LightGray = Color(0xFFCFD8DC)
+val OffWhite = Color(0xFFF5F5F5)
+val PureWhite = Color(0xFFFFFFFF)
 val DarkGray = Color(0xFF212121)
+

--- a/app/src/main/java/com/example/myapplication111/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/myapplication111/ui/theme/Theme.kt
@@ -1,36 +1,35 @@
 package com.example.myapplication111.ui.theme
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 
 private val DarkColorScheme = darkColorScheme(
-    primary = EpnBlue,
-    secondary = EpnRed,
+    primary = DeepBlue,
+    secondary = SlateGray,
     background = DarkGray,
     surface = DarkGray,
-    onPrimary = White,
-    onSecondary = White,
-    onBackground = White,
-    onSurface = White
+    onPrimary = PureWhite,
+    onSecondary = PureWhite,
+    onBackground = PureWhite,
+    onSurface = PureWhite
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = EpnBlue,
-    secondary = EpnRed,
-    background = White,
-    surface = OwlGray,
-    onPrimary = White,
-    onSecondary = White,
+    primary = DeepBlue,
+    secondary = SlateGray,
+    background = OffWhite,
+    surface = LightGray,
+    onPrimary = PureWhite,
+    onSecondary = PureWhite,
     onBackground = DarkGray,
     onSurface = DarkGray
 )
 
 @Composable
 fun MyApplication111Theme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
+    darkTheme: Boolean = true,
     content: @Composable () -> Unit
 ) {
     val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme


### PR DESCRIPTION
## Summary
- add neutral color palette with deep blue and grays
- use new colors and default to dark theme

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6893d134a08c83338b74eb92a20888a7