### PR TITLE
Show owl watermark background and simplify top bar

### DIFF
--- a/app/src/main/java/com/example/myapplication111/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication111/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -67,39 +68,44 @@ class MainActivity : ComponentActivity() {
         messages.clear()
     }
 
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    fun ChatScreen() {
-        var userMessage by remember { mutableStateOf("") }
-        val messages = this@MainActivity.messages
-        val context = this
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChatScreen() {
+    var userMessage by remember { mutableStateOf("") }
+    val messages = this@MainActivity.messages
+    val context = this
 
-        Scaffold(
-            topBar = {
-                TopAppBar(
-                    title = { Text("EPN Chat") },
-                    navigationIcon = {
-                        Image(
-                            painter = painterResource(R.drawable.ic_owl),
-                            contentDescription = "Owl icon",
-                            modifier = Modifier.padding(horizontal = 8.dp)
-                        )
-                    },
-                    actions = {
-                        IconButton(onClick = { newChat() }) {
-                            Icon(Icons.Default.Add, contentDescription = "New Chat")
-                        }
-                        IconButton(onClick = { clearHistory() }) {
-                            Icon(Icons.Default.Delete, contentDescription = "Clear History")
-                        }
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("EPN Chat") },
+                actions = {
+                    IconButton(onClick = { newChat() }) {
+                        Icon(Icons.Default.Add, contentDescription = "New Chat")
                     }
-                )
-            }
-        ) { padding ->
+                    IconButton(onClick = { clearHistory() }) {
+                        Icon(Icons.Default.Delete, contentDescription = "Clear History")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            Image(
+                painter = painterResource(R.drawable.ic_owl),
+                contentDescription = null,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .alpha(0.05f)
+                    .size(300.dp)
+            )
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(padding)
                     .padding(16.dp)
             ) {
                 LazyColumn(modifier = Modifier.weight(1f)) {
@@ -152,6 +158,7 @@ class MainActivity : ComponentActivity() {
             }
         }
     }
+}
 
     @Composable
     fun UserMessageBubble(text: String) {

--- a/app/src/main/res/drawable/ic_owl.xml
+++ b/app/src/main/res/drawable/ic_owl.xml
@@ -1,15 +1,11 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="24dp"
-    android:height="24dp"
+    android:width="256dp"
+    android:height="256dp"
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path
         android:fillColor="#000000"
-        android:pathData="M12,2C8,2 5,5 5,8c0,3 2,5 4,6v4l3-2 3,2v-4c2-1 4-3 4-6 0-3-3-6-7-6z"/>
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M9,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z"/>
-    <path
-        android:fillColor="#FFFFFF"
-        android:pathData="M15,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z"/>
+        android:fillAlpha="0.1"
+        android:fillType="evenOdd"
+        android:pathData="M12,2C8,2 5,5 5,8c0,3 2,5 4,6v4l3-2 3,2v-4c2-1 4-3 4-6 0-3-3-6-7-6z M9,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z M15,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z"/>
 </vector>


### PR DESCRIPTION
## Summary
- Restyle `ic_owl` vector for use as a faint background watermark
- Place owl drawable as low-opacity background in `ChatScreen`
- Drop owl icon from top bar to avoid duplication

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy; HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893e7b232648333ab8ede12a3ceada7