### PR TITLE
Fix ChatGPT response parsing and add chat history top bar

### DIFF
--- a/app/src/main/java/com/example/myapplication111/ChatGPTService.kt
+++ b/app/src/main/java/com/example/myapplication111/ChatGPTService.kt
@@ -5,6 +5,7 @@ import com.android.volley.toolbox.Volley
 import com.android.volley.toolbox.StringRequest
 import com.android.volley.Response
 import com.android.volley.Request
+import org.json.JSONObject
 
 class ChatGPTService(private val context: Context, private val apiKey: String) {
 
@@ -40,12 +41,16 @@ class ChatGPTService(private val context: Context, private val apiKey: String) {
     }
 
     private fun extraerRespuesta(json: String): String {
-        // Extrae el texto de la respuesta
-        val indexStart = json.indexOf("content") + 10
-        val indexEnd = json.indexOf("\"", indexStart)
-        return if (indexStart >= 0 && indexEnd > indexStart) {
-            json.substring(indexStart, indexEnd)
-        } else {
+        return try {
+            val jsonObj = JSONObject(json)
+            val choices = jsonObj.getJSONArray("choices")
+            if (choices.length() > 0) {
+                val message = choices.getJSONObject(0).getJSONObject("message")
+                message.getString("content")
+            } else {
+                "No se encontró contenido en la respuesta"
+            }
+        } catch (e: Exception) {
             "No se pudo leer la respuesta"
         }
     }

--- a/app/src/main/java/com/example/myapplication111/MainActivity.kt
+++ b/app/src/main/java/com/example/myapplication111/MainActivity.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.History
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -74,6 +75,8 @@ fun ChatScreen() {
     var userMessage by remember { mutableStateOf("") }
     val messages = this@MainActivity.messages
     val context = this
+    var showHistory by remember { mutableStateOf(false) }
+    var historyMessages by remember { mutableStateOf(listOf<Message>()) }
 
     Scaffold(
         topBar = {
@@ -82,6 +85,14 @@ fun ChatScreen() {
                 actions = {
                     IconButton(onClick = { newChat() }) {
                         Icon(Icons.Default.Add, contentDescription = "New Chat")
+                    }
+                    IconButton(onClick = {
+                        this@MainActivity.lifecycleScope.launch {
+                            historyMessages = db.messageDao().getAll().map { Message(it.sender, it.content) }
+                            showHistory = true
+                        }
+                    }) {
+                        Icon(Icons.Default.History, contentDescription = "View History")
                     }
                     IconButton(onClick = { clearHistory() }) {
                         Icon(Icons.Default.Delete, contentDescription = "Clear History")
@@ -157,6 +168,22 @@ fun ChatScreen() {
                 }
             }
         }
+    }
+    if (showHistory) {
+        AlertDialog(
+            onDismissRequest = { showHistory = false },
+            confirmButton = {
+                TextButton(onClick = { showHistory = false }) { Text("Cerrar") }
+            },
+            title = { Text("Historial") },
+            text = {
+                LazyColumn {
+                    items(historyMessages) { message ->
+                        Text("${message.sender}: ${message.content}")
+                    }
+                }
+            }
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- Parse OpenAI responses using JSON to restore chatbot replies
- Add history button in top bar with dialog listing stored messages

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893eabeb6908333b8f99de7357f0035