### PR TITLE
Add sender-based query to MessageDao

### DIFF
--- a/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
+++ b/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
@@ -11,4 +11,7 @@ interface MessageDao {
 
     @Query("SELECT * FROM messages ORDER BY timestamp ASC")
     suspend fun getAll(): List<MessageEntity>
+
+    @Query("SELECT * FROM messages WHERE sender = :sender ORDER BY timestamp ASC")
+    suspend fun getMessagesBySender(sender: String): List<MessageEntity>
 }


### PR DESCRIPTION
## Summary
- add query to fetch messages filtered by sender

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6893f464d8588333b2a09d4544c112c8