### PR TITLE
feat: modern owl-themed chat design

### DIFF
--- a/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
+++ b/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
@@ -11,4 +11,7 @@ interface MessageDao {
 
     @Query("SELECT * FROM messages ORDER BY timestamp ASC")
     suspend fun getAll(): List<MessageEntity>
+
+    @Query("DELETE FROM messages")
+    suspend fun clearAll()
 }

--- a/app/src/main/java/com/example/myapplication111/ui/theme/Color.kt
+++ b/app/src/main/java/com/example/myapplication111/ui/theme/Color.kt
@@ -2,7 +2,8 @@ package com.example.myapplication111.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
+val EpnBlue = Color(0xFF003C8F)
+val EpnRed = Color(0xFFD50000)
+val OwlGray = Color(0xFFF5F5F5)
 val White = Color(0xFFFFFFFF)
-val LightGray = Color(0xFFE0E0E0)
 val DarkGray = Color(0xFF212121)
-

--- a/app/src/main/java/com/example/myapplication111/ui/theme/Theme.kt
+++ b/app/src/main/java/com/example/myapplication111/ui/theme/Theme.kt
@@ -7,8 +7,8 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 
 private val DarkColorScheme = darkColorScheme(
-    primary = DarkGray,
-    secondary = LightGray,
+    primary = EpnBlue,
+    secondary = EpnRed,
     background = DarkGray,
     surface = DarkGray,
     onPrimary = White,
@@ -18,12 +18,12 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 private val LightColorScheme = lightColorScheme(
-    primary = White,
-    secondary = LightGray,
+    primary = EpnBlue,
+    secondary = EpnRed,
     background = White,
-    surface = LightGray,
-    onPrimary = DarkGray,
-    onSecondary = DarkGray,
+    surface = OwlGray,
+    onPrimary = White,
+    onSecondary = White,
     onBackground = DarkGray,
     onSurface = DarkGray
 )
@@ -41,4 +41,3 @@ fun MyApplication111Theme(
         content = content
     )
 }
-

--- a/app/src/main/res/drawable/ic_owl.xml
+++ b/app/src/main/res/drawable/ic_owl.xml
@@ -1,0 +1,15 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M12,2C8,2 5,5 5,8c0,3 2,5 4,6v4l3-2 3,2v-4c2-1 4-3 4-6 0-3-3-6-7-6z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15,6a1,1 0 1,0 0,2a1,1 0 1,0 0,-2z"/>
+</vector>


### PR DESCRIPTION
## Summary
- Refresh chat UI with owl-themed top bar and modern message bubbles
- Enable starting new conversations and clearing chat history
- Load and reuse messages asynchronously to prevent launch hang

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6893c7e50a0c8333bf08f0a442197973