### PR TITLE
Add DAO method to clear stored messages

### DIFF
--- a/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
+++ b/app/src/main/java/com/example/myapplication111/data/MessageDao.kt
@@ -15,4 +15,7 @@ interface MessageDao {
     @Query("SELECT * FROM messages WHERE sender = :sender ORDER BY timestamp ASC")
     suspend fun getMessagesBySender(sender: String): List<MessageEntity>
 
+    @Query("DELETE FROM messages")
+    suspend fun clearAll()
+
 }


### PR DESCRIPTION
## Summary
- allow clearing all messages from the database via `clearAll` in `MessageDao`

## Testing
- `./gradlew assembleDebug` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689401ffd21c833399eef6db56dd0253